### PR TITLE
Ensure pos widget callbacks do not block canvas redraw

### DIFF
--- a/web/types.js
+++ b/web/types.js
@@ -86,7 +86,7 @@ class Vec2PosWidget {
     }
 
     mouse(e, pos, node) {
-        if (e.type === 'pointermove') {
+        if (e.type === 'pointermove' || e.type === 'pointerdown') {
             this.value = [  (pos[0] / this.wWidth - 0.5) * 2.0, 
                             ((pos[1] - this.wY) / this.wHeight - 0.5) * 2.0];
             return true

--- a/web/types.js
+++ b/web/types.js
@@ -89,6 +89,7 @@ class Vec2PosWidget {
         if (e.type === 'pointermove') {
             this.value = [  (pos[0] / this.wWidth - 0.5) * 2.0, 
                             ((pos[1] - this.wY) / this.wHeight - 0.5) * 2.0];
+            return true
         }
     }
 
@@ -240,6 +241,7 @@ class Vec3PosWidget {
         }
         else if (e.type === 'pointerup') {
         }
+        return true
     }
 
     computeSize(width) {
@@ -464,6 +466,7 @@ class Vec4ColorWidget {
         let b = [p, p, t, v, v, q][mod];
 
         this.value = [r,g,b, 1.0];
+        return true
     }
 
     computeSize(width) {


### PR DESCRIPTION
Resolves #17

As part of a larger update to Litegraph, a bug in the `widget.mouse()` callback has been resolved.

The callback is expected to return a value - `true` to redraw the canvas, `false` / `undefined` to prevent canvas redraw.  This prevents demanding widgets from issuing too many full-canvas redraws.

- Adds return true to vec2/3/4 interactive widgets
- Adds a `pointerdown` update for the vec2 widget (if you click without dragging, nothing happens)

I am adding a temporary patch to revert LiteGraph to the bugged behaviour, so you may not be able to reproduce the issue.  It will be removed at some point, so merging this PR is still recommended.