### PR TITLE
Fixed input type bug in glslUniforms.

### DIFF
--- a/glsl_uniforms.py
+++ b/glsl_uniforms.py
@@ -9,16 +9,6 @@ class GlslUniforms:
                 # TODO: add support for vertex shader and 3D models
                 # "vertex_shader": ("STRING"),
                 # "3D_model": ("3D_MODEL", { "default": None }),
-
-                "u_tex0": ("IMAGE", { "multi": True }),
-                "u_tex1": ("IMAGE", { "multi": True }),
-                "u_tex2": ("IMAGE", { "multi": True }),
-                "u_tex3": ("IMAGE", { "multi": True }),
-
-                "u_val0": ("*", { "multi": True }),
-                "u_val1": ("*", { "multi": True }),
-                "u_val2": ("*", { "multi": True }),
-                "u_val3": ("*", { "multi": True }),
             }
         }
     


### PR DESCRIPTION
The glslUniforms node expects the 4 first inputs to be of type `u_tex` and the next 4 to be of type `u_val`. It fails otherwise.
This PR fixes this issue by aligning the behaviour of glslUniforms to that of glslViewer (flexible inputs).

![Screenshot 2025-01-30 200724](https://github.com/user-attachments/assets/d4f3caaa-907c-4e32-8983-39985375705a)
