### PR TITLE
Fixed loading of glslUniforms and glslViewer

### DIFF
--- a/web/utils.js
+++ b/web/utils.js
@@ -91,7 +91,7 @@ export const addInput = (node, index, str, type) => {
     if (index > firstUniformIndex) 
         name = getNextName(node, str);
     else
-        name = str + (index-firstUniformIndex+1)
+        name = str + Math.max(index-firstUniformIndex+1, 0);
 
     node.graph.beforeChange();
     

--- a/web/utils.js
+++ b/web/utils.js
@@ -71,12 +71,28 @@ export const getMaxIndex = (node, str) => {
 
 export const getNextName = (node, str) => { return str + (getMaxIndex(node, str) + 1); }
 
-export const addInput = (node, index, str, type, unique=true) => {
+export const findFirstUniformIndex = (node) => {
+    for (let i = 0; i < node.inputs.length; i++) {
+        if (node.inputs[i].name.startsWith("u_") || 
+            node.inputs[i].name === "uniforms" ||
+            node.inputs[i].name === "vertex_code" ||
+            node.inputs[i].name === "3D model"
+        ) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+export const addInput = (node, index, str, type) => {
     let name = str;
 
-    if (unique) 
+    let firstUniformIndex = findFirstUniformIndex(node);
+    if (index > firstUniformIndex) 
         name = getNextName(node, str);
-    
+    else
+        name = str + (index-firstUniformIndex+1)
+
     node.graph.beforeChange();
     
     node.inputs[index].name = name;

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -27,6 +27,27 @@ app.registerExtension({
             return r
         }
 
+        // List of supported callbacks:
+        // https://github.com/jagenjo/litegraph.js/tree/master/guides
+        // https://github.com/jagenjo/litegraph.js/blob/master/doc/files/.._src_litegraph.js.html
+        const onConfigure = nodeType.prototype.onConfigure;
+		nodeType.prototype.onConfigure = function () {
+		    const r = onConfigure ? onConfigure.apply(this, arguments) : undefined;
+			
+            console.log("CONFIGURE NODE " + nodeData.name );
+            console.log("INPUTS " + this.inputs.length);
+             for (let i = 0; i < this.inputs.length; i++) {
+                 console.log(this.inputs[i].name);
+            }
+
+            if (this.inputs.length > 1) {
+                let last_index = this.inputs.length - 1;
+                this.removeInput(last_index);
+            }
+            
+            return r;
+		};
+
         const onConnectionsChange = nodeType.prototype.onConnectionsChange
         nodeType.prototype.onConnectionsChange = function (...args) {
             const [_type, index, connected, link_info, ioSlot] = args

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -33,12 +33,6 @@ app.registerExtension({
         const onConfigure = nodeType.prototype.onConfigure;
 		nodeType.prototype.onConfigure = function () {
 		    const r = onConfigure ? onConfigure.apply(this, arguments) : undefined;
-			
-            console.log("CONFIGURE NODE " + nodeData.name );
-            console.log("INPUTS " + this.inputs.length);
-             for (let i = 0; i < this.inputs.length; i++) {
-                 console.log(this.inputs[i].name);
-            }
 
             if (this.inputs.length > 1) {
                 let last_index = this.inputs.length - 1;


### PR DESCRIPTION
Currently, behaviour of inputs when loading a workflow containing glslUniforms or glslViewer is broken.

How to reproduce:
* Create a glslViewer or glslUniforms node
* Connect a few inputs
* Save the workflow
* Close and load it again

Observed behaviour:
1. The inputs are not correctly numbered (`u_val0` has been replace with `u_val3`)
2. An extra `...` input appears each time the workflow is saved and loaded

![Screenshot 2025-01-31 140932](https://github.com/user-attachments/assets/942b93e8-db0a-46a5-ab55-c6d1404eea6f)

The PR fixes both these issues.